### PR TITLE
Make sure `builders` is available

### DIFF
--- a/bkcharts/__init__.py
+++ b/bkcharts/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+# expose internal packages
+from . import builders
 
 # defaults and constants
 from bokeh.plotting.helpers import DEFAULT_PALETTE; DEFAULT_PALETTE


### PR DESCRIPTION
When importing `bkcharts` or importing all contents from `bkcharts`, the `builders` package is not currently made available. However it was available before when this was part of `bokeh` 0.12.5. To fix this issue, simply do a relative import of `builders` in the `__init__` module of `bkcharts`.

Note: The previous behavior caused us a [testing issue]( https://travis-ci.org/conda-forge/bokeh-feedstock/jobs/242845253#L2386-L2390 ) in our `bokeh` package.